### PR TITLE
chore: upgrade python/pylint

### DIFF
--- a/imagemodal/mixins/scenario.py
+++ b/imagemodal/mixins/scenario.py
@@ -65,7 +65,7 @@ class XBlockWorkbenchMixin:
         Gather scenarios to be displayed in the workbench
         """
         module = cls.__module__
-        module = module.split('.')[0]
+        module = module.split('.', maxsplit=1)[0]
         directory = pkg_resources.resource_filename(module, 'scenarios')
         files = _find_files(directory)
         scenarios = _read_files(files)

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -15,10 +15,6 @@
 # using LTS django version
 Django<2.3
 
-# docutils version 0.17 is causing docs rendering to fail
-# See https://sourceforge.net/p/docutils/bugs/417/
-docutils==0.16
-
 # latest version is causing e2e failures in edx-platform.
 drf-jwt<1.19.1
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -49,7 +49,7 @@ pbr==5.6.0
     #   stevedore
 pycodestyle==2.7.0
     # via -r requirements/quality.in
-pylint==2.9.1
+pylint==2.9.3
     # via -r requirements/quality.in
 pymongo==3.11.4
     # via

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,7 +12,7 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-packaging==20.9
+packaging==21.0
     # via tox
 pluggy==0.13.1
     # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -29,7 +29,7 @@ filelock==3.0.12
     #   virtualenv
 idna==2.10
     # via requests
-packaging==20.9
+packaging==21.0
     # via
     #   -r requirements/tox.txt
     #   tox


### PR DESCRIPTION
This replaces https://github.com/edx/xblock-image-modal/pull/21 and fixes the failing (pylint) tests.

More detail is available in the commit message.